### PR TITLE
Save simulation stats

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "openBF"
 uuid = "e815b1a4-10eb-11ea-25f1-272ff651e618"
 authors = ["alessandro <alessandro_melis@rocketmail.com>"]
-version = "2.2.0"
+version = "2.3.0"
 
 [deps]
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"

--- a/docs/src/man/quickstart.md
+++ b/docs/src/man/quickstart.md
@@ -18,6 +18,7 @@ run_simulation(
         yaml_config_path::String;
         verbose::Bool = false,         # show progress bars
         out_files::Bool = false,       # save .out files with the all the cycles
+        save_stats::Bool = false,      # save .conv file with simulation stats
         )
 ```
 
@@ -27,7 +28,7 @@ Running a simulation consists in calling
 
 ```julia
 using openBF
-run_simulation("input.yml", verbose=true)
+run_simulation("input.yml", verbose=true, save_stats=true)
 ```
 
 This will create a `<project_name>_results` folder containing all the output files from the simulation.
@@ -40,6 +41,16 @@ By default only `.last` files are saved. Thes contains only the _last_ simulated
 
 You can also set `out_files = true` when calling `run_simulation`. This results in the writing of `.out` files which contain the _whole_ simulation history, i.e., all the cardiac cycles simulated.
 
-### Format
+When setting `save_stats=true`, a `<project_name>.conv` file is written in the results dolder. This reads
+
+```
+<has the simulation converged> # boolean: true or false
+<elapsed cardiac cycles> # integer
+<elapsed time> # float, seconds
+<memory allocated> # integer, bytes
+<garbace collection % time> # float, percentage
+```
+
+### `.last`/`.out` Format
 
 These files contain as many rows as defined in the config by the `jump` parameter (default `100`), and 6 columns. The first column contains the simulation time for the current cardiac cycles; column 2-6 report waveforms at five locations along the vessel, namely _inlet_, _1/4th_ of the length, _mid-point_, _3/4th_ of the length and _outlet_.


### PR DESCRIPTION
When setting `save_stats=true`, a `<project_name>.conv` file is written in the results dolder. This reads

```
<has the simulation converged> # boolean: true or false
<elapsed cardiac cycles> # integer
<elapsed time> # float, seconds
<memory allocated> # integer, bytes
<garbace collection % time> # float, percentage
```
